### PR TITLE
Fix "ValueError: incorrect padding" when calling the decode method on a valid token

### DIFF
--- a/src/ujwt/jwt.py
+++ b/src/ujwt/jwt.py
@@ -53,6 +53,10 @@ class Jwt:
         if isinstance(s, str):
             s = bytes(data, "utf-8")
 
+        rem = len(s) % 4
+        if rem > 0:
+            s += b"=" * (4 - rem)
+
         msg = s.replace(b"-", b"+").replace(b"_", b"/")
         return ubinascii.a2b_base64(msg)
 


### PR DESCRIPTION
Running on

```
MicroPython v1.20.0 on 2023-04-26; Raspberry Pi Pico W with RP2040
```

I always get an error when decoding a token:

```python
>>> import ujwt.jwt
>>> t = ujwt.jwt.Jwt('sec').encode({'a':'b'})
>>> ujwt.jwt.Jwt('sec').decode(t)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "ujwt/jwt.py", line 40, in decode
  File "ujwt/jwt.py", line 57, in _decodeBase64
ValueError: incorrect padding
```

The reason is that the encode method (correctly) strips base64 padding, but the decode method doesn't restore it.

With the pull request applied, the example works correctly:

```python
>>> import ujwt.jwt
>>> t = ujwt.jwt.Jwt('sec').encode({'a':'b'})
>>> ujwt.jwt.Jwt('sec').decode(t)
{'a': 'b'}
```